### PR TITLE
[Node] Custom ID

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,7 @@ const babelOptions = require('./scripts/getBabelOptions')({
     'React': 'react',
     'ReactDOM': 'react-dom',
     'ReactNative': 'react-native',
+    'ReactNative/Libraries/Renderer/src/renderers/native/ReactNative': 'react-native/Libraries/Renderer/src/renderers/native/ReactNative',
     'RelayRuntime': 'relay-runtime',
     'signedsource': 'signedsource',
     'StaticContainer.react': 'react-static-container',

--- a/packages/babel-plugin-relay/RelayQLPrinter.js
+++ b/packages/babel-plugin-relay/RelayQLPrinter.js
@@ -740,6 +740,7 @@ module.exports = function(t: any, options: PrinterOptions): Function {
   ): boolean {
     return (
       node.getType().mayImplement('Node') &&
+      node.getSelections().length > 0 &&
       !node
         .getSelections()
         .some(

--- a/packages/react-relay/classic/tools/relayUnstableBatchedUpdates.native.js
+++ b/packages/react-relay/classic/tools/relayUnstableBatchedUpdates.native.js
@@ -13,5 +13,13 @@
 'use strict';
 
 const ReactNative = require('ReactNative');
+let batchedUpdates = undefined;
 
-module.exports = ReactNative.unstable_batchedUpdates;
+if (ReactNative.unstable_batchedUpdates) {
+  batchedUpdates = ReactNative.unstable_batchedUpdates;
+} else {
+  const Renderer = require('ReactNative/Libraries/Renderer/src/renderers/native/ReactNative');
+  batchedUpdates = Renderer.unstable_batchedUpdates;
+}
+
+module.exports = batchedUpdates;

--- a/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
@@ -19,6 +19,7 @@ const RelayParser = require('RelayParser');
 const RelayPrinter = require('RelayPrinter');
 const RelayTestSchema = require('RelayTestSchema');
 const getGoldenMatchers = require('getGoldenMatchers');
+const { buildSchema } = require('graphql')
 
 describe('RelayGenerateRequisiteFieldsTransform', () => {
   beforeEach(() => {
@@ -44,4 +45,50 @@ describe('RelayGenerateRequisiteFieldsTransform', () => {
       return documents.join('\n');
     });
   });
+
+  it('inflects DataID field from Node interface', () => {
+    const schema = buildSchema(`
+      schema {
+        query: Query
+      }
+
+      type Query {
+        node(__id: ID): Node
+        artists: [Artist]
+      }
+
+      interface Node {
+        __id: ID!
+      }
+
+      type Artist implements Node {
+        __id: ID!
+        name: String!
+      }
+    `);
+    const ast = RelayParser.parse(schema, `
+      query ArtistsQuery {
+        artists {
+          name
+        }
+      }
+    `)
+    const context = ast.reduce(
+      (ctx, node) => ctx.add(node),
+      new RelayCompilerContext(RelayTestSchema)
+    );
+    const nextContext = RelayGenerateRequisiteFieldsTransform.transform(context);
+    const documents = [];
+    nextContext.documents().map(doc => {
+      documents.push(RelayPrinter.print(doc));
+    });
+    expect(documents.join('\n')).toEqual(`
+      query ArtistsQuery {
+        artists {
+          __id
+          name
+        }
+      }
+    `.replace(/^\s{6}/gm, '').trim())
+  })
 });


### PR DESCRIPTION
- [x] Make Classic compatible with React Native 0.45, which has moved files around for the new Fiber renderer in React 16.
- [x] Fixed an infinite recursion case that would blow up the stack. It happens with the `IdFragment`, so not yet sure if it’s a side-effect of us using a custom ID.
- [ ] Double-check if the recursion bug still applies after making Relay work with a custom Node ID.