### PR TITLE
[Node] Custom ID inflected from schema.

### DIFF
--- a/packages/relay-compiler/ARCHITECTURE.md
+++ b/packages/relay-compiler/ARCHITECTURE.md
@@ -91,4 +91,4 @@ foo {
 }
 ```
 
-- `GenerateRequisiteFieldTransform`: This optional, Relay-specific transform inserts `id` fields for globally identifiable objects and `__typename` fields wherever the type cannot be statically determined (e.g. for unions).
+- `GenerateRequisiteFieldTransform`: This optional, Relay-specific transform inserts object identification fields (which is either an `ID!` field on the `Node` interface or defaults to `id`) and `__typename` fields wherever the type cannot be statically determined (e.g. for unions).

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -27,7 +27,7 @@ const writeLegacyFlowFile = require('./writeLegacyFlowFile');
 const writeRelayGeneratedFile = require('./writeRelayGeneratedFile');
 
 const {isOperationDefinitionAST} = require('GraphQLSchemaUtils');
-const {generate} = require('RelayCodeGenerator');
+const RelayCodeGenerator = require('RelayCodeGenerator');
 const {Map: ImmutableMap} = require('immutable');
 
 import type {RelayGeneratedNode} from 'RelayCodeGenerator';
@@ -144,11 +144,12 @@ class RelayFileWriter implements FileWriterInterface {
     );
 
     const compilerContext = new RelayCompilerContext(extendedSchema);
+    const codeGenerator = new RelayCodeGenerator(compilerContext.getNodeIDFieldName());
     const compiler = new RelayCompiler(
       this._baseSchema,
       compilerContext,
       this._config.compilerTransforms,
-      generate,
+      codeGenerator.generate.bind(codeGenerator),
     );
 
     const getGeneratedDirectory = definitionName => {

--- a/packages/relay-compiler/core/__tests__/RelayCodeGenerator-test.js
+++ b/packages/relay-compiler/core/__tests__/RelayCodeGenerator-test.js
@@ -31,9 +31,10 @@ describe('RelayCodeGenerator', () => {
       const context = new RelayCompilerContext(RelayTestSchema).addAll(
         definitions,
       );
+      const codeGenerator = new RelayCodeGenerator(context.getNodeIDFieldName());
       return context
         .documents()
-        .map(doc => prettyStringify(RelayCodeGenerator.generate(doc)))
+        .map(doc => prettyStringify(codeGenerator.generate(doc)))
         .join('\n\n');
     });
   });

--- a/packages/relay-compiler/core/__tests__/RelayCompiler-test.js
+++ b/packages/relay-compiler/core/__tests__/RelayCompiler-test.js
@@ -15,7 +15,7 @@
 require('configureForRelayOSS');
 
 const {transformASTSchema} = require('ASTConvert');
-const {generate} = require('RelayCodeGenerator');
+const RelayCodeGenerator = require('RelayCodeGenerator');
 const RelayCompiler = require('RelayCompiler');
 const RelayCompilerContext = require('RelayCompilerContext');
 const RelayIRTransforms = require('RelayIRTransforms');
@@ -36,11 +36,13 @@ describe('RelayCompiler', () => {
         RelayTestSchema,
         RelayIRTransforms.schemaExtensions,
       );
+      const context = new RelayCompilerContext(relaySchema);
+      const codeGenerator = new RelayCodeGenerator(context.getNodeIDFieldName());
       const compiler = new RelayCompiler(
         RelayTestSchema,
-        new RelayCompilerContext(relaySchema),
+        context,
         RelayIRTransforms,
-        generate,
+        codeGenerator.generate.bind(codeGenerator),
       );
       compiler.addDefinitions(parseGraphQLText(relaySchema, text).definitions);
       return Array.from(compiler.compile().values())

--- a/packages/relay-compiler/core/__tests__/fixtures/code-generator/linked-handle-field.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/code-generator/linked-handle-field.golden.txt
@@ -27,7 +27,8 @@
           "storageKey": null
         }
       ],
-      "storageKey": "friends{\"first\":10}"
+      "storageKey": "friends{\"first\":10}",
+      "idField": "id"
     },
     {
       "kind": "LinkedHandle",

--- a/packages/relay-compiler/core/__tests__/fixtures/code-generator/query-with-fragment-variables.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/code-generator/query-with-fragment-variables.golden.txt
@@ -72,7 +72,8 @@
           ]
         }
       ],
-      "storageKey": null
+      "storageKey": null,
+      "idField": "id"
     }
   ]
 }
@@ -133,13 +134,16 @@
                   ]
                 }
               ],
-              "storageKey": null
+              "storageKey": null,
+              "idField": "id"
             }
           ],
-          "storageKey": null
+          "storageKey": null,
+          "idField": "id"
         }
       ],
-      "storageKey": "friends{\"first\":10}"
+      "storageKey": "friends{\"first\":10}",
+      "idField": "id"
     }
   ],
   "type": "User"
@@ -181,7 +185,8 @@
           "storageKey": null
         }
       ],
-      "storageKey": null
+      "storageKey": null,
+      "idField": "id"
     }
   ],
   "type": "User"

--- a/packages/relay-compiler/core/__tests__/fixtures/compiler/client-fields.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/compiler/client-fields.golden.txt
@@ -48,10 +48,12 @@
                   "storageKey": null
                 }
               ],
-              "storageKey": null
+              "storageKey": null,
+              "idField": "id"
             }
           ],
-          "storageKey": null
+          "storageKey": null,
+          "idField": "id"
         },
         {
           "kind": "LinkedField",
@@ -69,10 +71,12 @@
               "storageKey": null
             }
           ],
-          "storageKey": null
+          "storageKey": null,
+          "idField": "id"
         }
       ],
-      "storageKey": null
+      "storageKey": null,
+      "idField": "id"
     },
     {
       "kind": "FragmentSpread",
@@ -165,7 +169,8 @@
             "args": null
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ],
     "type": "Query"
@@ -217,7 +222,8 @@
             "storageKey": null
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ]
   }

--- a/packages/relay-compiler/core/__tests__/fixtures/compiler/connection.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/compiler/connection.golden.txt
@@ -116,7 +116,8 @@
                                             "storageKey": null
                                           }
                                         ],
-                                        "storageKey": null
+                                        "storageKey": null,
+                                        "idField": "id"
                                       },
                                       {
                                         "kind": "ScalarField",
@@ -126,7 +127,8 @@
                                         "storageKey": null
                                       }
                                     ],
-                                    "storageKey": null
+                                    "storageKey": null,
+                                    "idField": "id"
                                   },
                                   {
                                     "kind": "LinkedField",
@@ -151,13 +153,16 @@
                                         "storageKey": null
                                       }
                                     ],
-                                    "storageKey": null
+                                    "storageKey": null,
+                                    "idField": "id"
                                   }
                                 ],
-                                "storageKey": null
+                                "storageKey": null,
+                                "idField": "id"
                               }
                             ],
-                            "storageKey": null
+                            "storageKey": null,
+                            "idField": "id"
                           },
                           {
                             "kind": "ScalarField",
@@ -167,7 +172,8 @@
                             "storageKey": null
                           }
                         ],
-                        "storageKey": null
+                        "storageKey": null,
+                        "idField": "id"
                       },
                       {
                         "kind": "ScalarField",
@@ -177,7 +183,8 @@
                         "storageKey": null
                       }
                     ],
-                    "storageKey": null
+                    "storageKey": null,
+                    "idField": "id"
                   },
                   {
                     "kind": "LinkedField",
@@ -202,15 +209,18 @@
                         "storageKey": null
                       }
                     ],
-                    "storageKey": null
+                    "storageKey": null,
+                    "idField": "id"
                   }
                 ],
-                "storageKey": null
+                "storageKey": null,
+                "idField": "id"
               }
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ],
     "type": "Query"
@@ -389,7 +399,8 @@
                                             "storageKey": null
                                           }
                                         ],
-                                        "storageKey": null
+                                        "storageKey": null,
+                                        "idField": "id"
                                       },
                                       {
                                         "kind": "ScalarField",
@@ -399,7 +410,8 @@
                                         "storageKey": null
                                       }
                                     ],
-                                    "storageKey": null
+                                    "storageKey": null,
+                                    "idField": "id"
                                   },
                                   {
                                     "kind": "LinkedField",
@@ -424,10 +436,12 @@
                                         "storageKey": null
                                       }
                                     ],
-                                    "storageKey": null
+                                    "storageKey": null,
+                                    "idField": "id"
                                   }
                                 ],
-                                "storageKey": "friends{\"first\":10}"
+                                "storageKey": "friends{\"first\":10}",
+                                "idField": "id"
                               },
                               {
                                 "kind": "LinkedHandle",
@@ -453,7 +467,8 @@
                                 "storageKey": null
                               }
                             ],
-                            "storageKey": null
+                            "storageKey": null,
+                            "idField": "id"
                           },
                           {
                             "kind": "ScalarField",
@@ -470,7 +485,8 @@
                             "storageKey": null
                           }
                         ],
-                        "storageKey": null
+                        "storageKey": null,
+                        "idField": "id"
                       },
                       {
                         "kind": "ScalarField",
@@ -480,7 +496,8 @@
                         "storageKey": null
                       }
                     ],
-                    "storageKey": null
+                    "storageKey": null,
+                    "idField": "id"
                   },
                   {
                     "kind": "LinkedField",
@@ -505,10 +522,12 @@
                         "storageKey": null
                       }
                     ],
-                    "storageKey": null
+                    "storageKey": null,
+                    "idField": "id"
                   }
                 ],
-                "storageKey": "comments{\"first\":10}"
+                "storageKey": "comments{\"first\":10}",
+                "idField": "id"
               },
               {
                 "kind": "LinkedHandle",
@@ -529,7 +548,8 @@
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ]
   }

--- a/packages/relay-compiler/core/__tests__/fixtures/compiler/kitchen-sink.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/compiler/kitchen-sink.golden.txt
@@ -77,7 +77,8 @@
           "storageKey": null
         }
       ],
-      "storageKey": null
+      "storageKey": null,
+      "idField": "id"
     },
     {
       "kind": "LinkedField",
@@ -116,7 +117,8 @@
           "storageKey": null
         }
       ],
-      "storageKey": "profilePicture{\"size\":32}"
+      "storageKey": "profilePicture{\"size\":32}",
+      "idField": "id"
     },
     {
       "kind": "LinkedField",
@@ -155,7 +157,8 @@
           "storageKey": null
         }
       ],
-      "storageKey": null
+      "storageKey": null,
+      "idField": "id"
     },
     {
       "kind": "LinkedField",
@@ -180,7 +183,8 @@
           "storageKey": null
         }
       ],
-      "storageKey": null
+      "storageKey": null,
+      "idField": "id"
     },
     {
       "kind": "Condition",
@@ -281,7 +285,8 @@
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ],
     "type": "Query"
@@ -383,7 +388,8 @@
                         "storageKey": null
                       }
                     ],
-                    "storageKey": "friends{\"first\":5}"
+                    "storageKey": "friends{\"first\":5}",
+                    "idField": "id"
                   },
                   {
                     "kind": "LinkedField",
@@ -422,7 +428,8 @@
                         "storageKey": null
                       }
                     ],
-                    "storageKey": "profilePicture{\"size\":32}"
+                    "storageKey": "profilePicture{\"size\":32}",
+                    "idField": "id"
                   },
                   {
                     "kind": "LinkedField",
@@ -461,7 +468,8 @@
                         "storageKey": null
                       }
                     ],
-                    "storageKey": null
+                    "storageKey": null,
+                    "idField": "id"
                   },
                   {
                     "kind": "LinkedField",
@@ -486,14 +494,16 @@
                         "storageKey": null
                       }
                     ],
-                    "storageKey": null
+                    "storageKey": null,
+                    "idField": "id"
                   }
                 ]
               }
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ]
   }

--- a/packages/relay-compiler/core/__tests__/fixtures/compiler/linked-handle-field.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/compiler/linked-handle-field.golden.txt
@@ -47,12 +47,14 @@
                     "storageKey": null
                   }
                 ],
-                "storageKey": null
+                "storageKey": null,
+                "idField": "id"
               }
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ],
     "type": "Query"
@@ -130,7 +132,8 @@
                     "storageKey": null
                   }
                 ],
-                "storageKey": "friends{\"first\":10}"
+                "storageKey": "friends{\"first\":10}",
+                "idField": "id"
               },
               {
                 "kind": "LinkedHandle",
@@ -151,7 +154,8 @@
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ]
   }

--- a/packages/relay-compiler/core/__tests__/fixtures/compiler/scalar-handle-field.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/compiler/scalar-handle-field.golden.txt
@@ -41,7 +41,8 @@
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ],
     "type": "Query"
@@ -115,7 +116,8 @@
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ]
   }

--- a/packages/relay-compiler/core/__tests__/fixtures/compiler/unions.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/compiler/unions.golden.txt
@@ -40,7 +40,8 @@
                     "storageKey": null
                   }
                 ],
-                "storageKey": null
+                "storageKey": null,
+                "idField": "id"
               }
             ]
           },
@@ -58,7 +59,8 @@
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ],
     "type": "Query"
@@ -115,7 +117,8 @@
                     "storageKey": null
                   }
                 ],
-                "storageKey": null
+                "storageKey": null,
+                "idField": "id"
               }
             ]
           },
@@ -133,7 +136,8 @@
             ]
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ]
   }

--- a/packages/relay-compiler/core/__tests__/fixtures/compiler/viewer-query.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/compiler/viewer-query.golden.txt
@@ -29,10 +29,12 @@
                 "storageKey": null
               }
             ],
-            "storageKey": null
+            "storageKey": null,
+            "idField": "id"
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       }
     ],
     "type": "Query"
@@ -78,10 +80,12 @@
                 "storageKey": null
               }
             ],
-            "storageKey": null
+            "storageKey": null,
+            "idField": "id"
           }
         ],
-        "storageKey": null
+        "storageKey": null,
+        "idField": "id"
       },
       {
         "kind": "LinkedHandle",

--- a/packages/relay-compiler/graphql-compiler/core/GraphQLSchemaUtils.js
+++ b/packages/relay-compiler/graphql-compiler/core/GraphQLSchemaUtils.js
@@ -89,7 +89,7 @@ function canHaveSelections(type: GraphQLType): boolean {
  *
  * https://github.com/graphql/graphql-future/blob/master/01%20-%20__id.md
  */
-function hasID(schema: GraphQLSchema, type: GraphQLCompositeType): boolean {
+function hasID(schema: GraphQLSchema, type: GraphQLCompositeType, fieldName: string): boolean {
   const unmodifiedType = getRawType(type);
   invariant(
     unmodifiedType instanceof GraphQLObjectType ||
@@ -99,7 +99,7 @@ function hasID(schema: GraphQLSchema, type: GraphQLCompositeType): boolean {
     type,
   );
   const idType = schema.getType(ID_TYPE);
-  const idField = unmodifiedType.getFields()[ID];
+  const idField = unmodifiedType.getFields()[fieldName];
   return idField && getRawType(idField.type) === idType;
 }
 

--- a/packages/relay-compiler/transforms/RelayGenerateRequisiteFieldsTransform.js
+++ b/packages/relay-compiler/transforms/RelayGenerateRequisiteFieldsTransform.js
@@ -124,20 +124,20 @@ function generateIDSelections(
   type: GraphQLType,
 ): ?Array<Selection> {
   const generatedNodeIdSelections = generateSpecificIDSelections(context, field, type, context.getNodeIDFieldName());
-  if (!generatedNodeIdSelections) {
+  if (generatedNodeIdSelections === null) {
     // The field already has an unaliased selection for the Node ID field.
     return null;
-  } else if (generatedNodeIdSelections.length > 0) {
-    return generatedNodeIdSelections;
+  } else if (generatedNodeIdSelections) {
+    return [generatedNodeIdSelections];
   }
 
   if (context.getNodeIDFieldName() !== ID) {
     const generatedFallbackIdSelections = generateSpecificIDSelections(context, field, type, ID);
-    if (!generatedFallbackIdSelections) {
+    if (generatedFallbackIdSelections === null) {
       // The field already has an unaliased selection for the fallback ID field.
       return null;
-    } else if (generatedFallbackIdSelections.length > 0) {
-      return generatedFallbackIdSelections;
+    } else if (generatedFallbackIdSelections) {
+      return [generatedFallbackIdSelections];
     }
   }
 
@@ -170,11 +170,10 @@ function generateSpecificIDSelections(
   field: LinkedField,
   type: GraphQLType,
   idFieldName: string,
-): ?Array<Selection> {
+): ?Selection {
   if (hasUnaliasedSelection(field, idFieldName)) {
     return null;
   }
-  const generatedSelections = []
   const unmodifiedType = assertCompositeType(getRawType(type));
   // Object or  Interface type that has `id` field
   if (
@@ -182,9 +181,9 @@ function generateSpecificIDSelections(
     hasID(context.schema, unmodifiedType, idFieldName)
   ) {
     const idType = assertLeafType(context.schema.getType(ID_TYPE));
-    generatedSelections.push(buildIdSelection(idType, idFieldName));
+    return buildIdSelection(idType, idFieldName);
   }
-  return generatedSelections;
+  return undefined;
 }
 
 /**

--- a/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
@@ -46,51 +46,161 @@ describe('RelayGenerateRequisiteFieldsTransform', () => {
     });
   });
 
-  it('inflects DataID field from Node interface', () => {
+  describe('concerning a custom Node ID field', () => {
     const schema = buildSchema(`
       schema {
         query: Query
       }
 
       type Query {
-        node(__id: ID): Node
-        artists: [Artist]
+        node(__id: ID!): Node
+        artist(slug: String!): Artist
+        artwork(slug: String!): Artwork
       }
 
       interface Node {
         __id: ID!
       }
 
+      type Painting {
+        __id: ID!
+        width: Float!
+        height: Float!
+      }
+
+      type Statue {
+        __id: ID!
+        width: Float!
+        height: Float!
+        depth: Float!
+      }
+
+      union Artwork = Painting | Statue
+
       type Artist implements Node {
         __id: ID!
         name: String!
+        artworks: [Artwork]
       }
     `);
-    const ast = RelayParser.parse(schema, `
-      query ArtistsQuery {
-        artists {
-          name
-        }
-      }
-    `)
-    const context = ast.reduce(
-      (ctx, node) => ctx.add(node),
-      new RelayCompilerContext(schema)
-    );
-    const nextContext = RelayGenerateRequisiteFieldsTransform.transform(context);
-    const documents = [];
-    nextContext.documents().map(doc => {
-      documents.push(RelayPrinter.print(doc));
-    });
-    expect(documents.join('\n').trim()).toEqual(`
-      query ArtistsQuery {
-        artists {
-          name
-          ... on Node {
+
+    it('inflects the ID field name from the schema and tests if an unaliased selection for it exists', () => {
+      const ast = RelayParser.parse(schema, `
+        query ArtistQuery {
+          artist(slug: "banksy") {
             __id
           }
         }
-      }
-    `.replace(/^\s{6}/gm, '').trim())
-  })
+      `);
+      const context = ast.reduce(
+        (ctx, node) => ctx.add(node),
+        new RelayCompilerContext(schema)
+      );
+      const nextContext = RelayGenerateRequisiteFieldsTransform.transform(context);
+      const documents = [];
+      nextContext.documents().map(doc => {
+        documents.push(RelayPrinter.print(doc));
+      });
+      expect(documents.join('\n').trim()).toEqual(`
+        query ArtistQuery {
+          artist(slug: "banksy") {
+            __id
+          }
+        }
+      `.replace(/^\s{8}/gm, '').trim());
+    });
+
+    it('inflects the ID field name from the schema for concrete types', () => {
+      const ast = RelayParser.parse(schema, `
+        query ArtistQuery {
+          artist(slug: "banksy") {
+            name
+          }
+        }
+      `);
+      const context = ast.reduce(
+        (ctx, node) => ctx.add(node),
+        new RelayCompilerContext(schema)
+      );
+      const nextContext = RelayGenerateRequisiteFieldsTransform.transform(context);
+      const documents = [];
+      nextContext.documents().map(doc => {
+        documents.push(RelayPrinter.print(doc));
+      });
+      expect(documents.join('\n').trim()).toEqual(`
+        query ArtistQuery {
+          artist(slug: "banksy") {
+            name
+            __id
+          }
+        }
+      `.replace(/^\s{8}/gm, '').trim());
+    });
+
+    it('inflects the ID field name from the schema for the `node` field', () => {
+      const ast = RelayParser.parse(schema, `
+        query NodeFieldQuery {
+          node(__id: "Artist:banksy") {
+            __typename
+          }
+        }
+      `);
+      const context = ast.reduce(
+        (ctx, node) => ctx.add(node),
+        new RelayCompilerContext(schema)
+      );
+      const nextContext = RelayGenerateRequisiteFieldsTransform.transform(context);
+      const documents = [];
+      nextContext.documents().map(doc => {
+        documents.push(RelayPrinter.print(doc));
+      });
+      expect(documents.join('\n').trim()).toEqual(`
+        query NodeFieldQuery {
+          node(__id: "Artist:banksy") {
+            __typename
+            __id
+          }
+        }
+      `.replace(/^\s{8}/gm, '').trim());
+    });
+
+    it('inflects the ID field name from the schema for union types', () => {
+      const ast = RelayParser.parse(schema, `
+        query ArtworkQuery {
+          artwork(slug: "mona-lisa") {
+            ... on Painting {
+              width
+              height
+            }
+          }
+        }
+      `);
+      const context = ast.reduce(
+        (ctx, node) => ctx.add(node),
+        new RelayCompilerContext(schema)
+      );
+      const nextContext = RelayGenerateRequisiteFieldsTransform.transform(context);
+      const documents = [];
+      nextContext.documents().map(doc => {
+        documents.push(RelayPrinter.print(doc));
+      });
+      expect(documents.join('\n').trim()).toEqual(`
+        query ArtworkQuery {
+          artwork(slug: "mona-lisa") {
+            __typename
+            ... on Painting {
+              width
+              height
+            }
+            ... on Painting {
+              __id
+            }
+            ... on Statue {
+              __id
+            }
+          }
+        }
+      `.replace(/^\s{8}/gm, '').trim());
+    });
+  });
 });

--- a/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
@@ -46,7 +46,7 @@ describe('RelayGenerateRequisiteFieldsTransform', () => {
     });
   });
 
-  it('inflects DataID field from Node interface', () => {
+  it.only('inflects DataID field from Node interface', () => {
     const schema = buildSchema(`
       schema {
         query: Query
@@ -82,11 +82,13 @@ describe('RelayGenerateRequisiteFieldsTransform', () => {
     nextContext.documents().map(doc => {
       documents.push(RelayPrinter.print(doc));
     });
-    expect(documents.join('\n')).toEqual(`
+    expect(documents.join('\n').trim()).toEqual(`
       query ArtistsQuery {
         artists {
-          __id
           name
+          ... on Node {
+            __id
+          }
         }
       }
     `.replace(/^\s{6}/gm, '').trim())

--- a/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
@@ -19,7 +19,7 @@ const RelayPrinter = require('RelayPrinter');
 const RelayTestSchema = require('RelayTestSchema');
 
 const getGoldenMatchers = require('getGoldenMatchers');
-const { buildSchema } = require('graphql')
+const { buildSchema } = require('graphql');
 
 describe('RelayGenerateRequisiteFieldsTransform', () => {
   beforeEach(() => {

--- a/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/RelayGenerateRequisiteFieldsTransform-test.js
@@ -46,7 +46,7 @@ describe('RelayGenerateRequisiteFieldsTransform', () => {
     });
   });
 
-  it.only('inflects DataID field from Node interface', () => {
+  it('inflects DataID field from Node interface', () => {
     const schema = buildSchema(`
       schema {
         query: Query
@@ -75,7 +75,7 @@ describe('RelayGenerateRequisiteFieldsTransform', () => {
     `)
     const context = ast.reduce(
       (ctx, node) => ctx.add(node),
-      new RelayCompilerContext(RelayTestSchema)
+      new RelayCompilerContext(schema)
     );
     const nextContext = RelayGenerateRequisiteFieldsTransform.transform(context);
     const documents = [];

--- a/packages/relay-runtime/ARCHITECTURE.md
+++ b/packages/relay-runtime/ARCHITECTURE.md
@@ -14,7 +14,7 @@ The Relay runtime is a full-featured GraphQL client that is designed for high pe
 
 ## Comparison to Classic Relay
 
-For users of classic Relay, note that the runtime makes as few assumptions as possible about GraphQL. Compared to earlier versions of Relay there is no concept of routes, there are no limitations on mutation input arguments or side-effects, arbitrary root fields just work, etc. At present, the main restriction from classic Relay that remains is the use of the `Node` interface and `id` field for object identification. However there is no fundamental reason that this restriction can't be relaxed (there is a single place in the codebase where object identity is determined), and we welcome feedback from the community about ways to support customizable object identity without negatively impacting performance.
+For users of classic Relay, note that the runtime makes as few assumptions as possible about GraphQL. Compared to earlier versions of Relay there is no concept of routes, there are no limitations on mutation input arguments or side-effects, arbitrary root fields just work, etc. Like classic Relay, modern Relay still uses the `Node` interface for object identification, however modern Relay will inflect the object identification field from the interface by searching for an `ID!` field.
 
 ## Data Types
 

--- a/packages/relay-runtime/__mocks__/RelayModernTestUtils.js
+++ b/packages/relay-runtime/__mocks__/RelayModernTestUtils.js
@@ -158,9 +158,10 @@ const RelayModernTestUtils = {
     context = ast.reduce((ctx, node) => ctx.add(node), context);
     context = (transforms || [])
       .reduce((ctx, {transform}) => transform(ctx), context);
+    const codeGenerator = new RelayCodeGenerator(context.getNodeIDFieldName())
     const documentMap = {};
     context.documents().forEach(node => {
-      documentMap[node.name] = RelayCodeGenerator.generate(node);
+      documentMap[node.name] = codeGenerator.generate(node);
     });
     return documentMap;
   },
@@ -175,7 +176,7 @@ const RelayModernTestUtils = {
     schema?: ?GraphQLSchema,
   ): {[key: string]: ConcreteBatch | ConcreteFragment} {
     const {transformASTSchema} = require('ASTConvert');
-    const {generate} = require('RelayCodeGenerator');
+    const RelayCodeGenerator = require('RelayCodeGenerator');
     const RelayCompiler = require('RelayCompiler');
     const RelayCompilerContext = require('RelayCompilerContext');
     const RelayIRTransforms = require('RelayIRTransforms');
@@ -187,11 +188,13 @@ const RelayModernTestUtils = {
       schema,
       RelayIRTransforms.schemaExtensions,
     );
+    const context = new RelayCompilerContext(relaySchema);
+    const codeGenerator = new RelayCodeGenerator(context.getNodeIDFieldName())
     const compiler = new RelayCompiler(
       schema,
-      new RelayCompilerContext(relaySchema),
+      context,
       RelayIRTransforms,
-      generate,
+      codeGenerator.generate.bind(codeGenerator),
     );
 
     compiler.addDefinitions(parseGraphQLText(relaySchema, text).definitions);

--- a/packages/relay-runtime/__mocks__/RelayModernTestUtils.js
+++ b/packages/relay-runtime/__mocks__/RelayModernTestUtils.js
@@ -146,15 +146,18 @@ const RelayModernTestUtils = {
     transforms?: ?Array<{
       transform: (context: RelayCompilerContext) => RelayCompilerContext,
     }>,
+    schema?: ?GraphQLSchema,
   ): {[key: string]: ConcreteRoot | ConcreteFragment} {
     const RelayCodeGenerator = require('RelayCodeGenerator');
     // eslint-disable-next-line no-shadow
     const RelayCompilerContext = require('RelayCompilerContext');
     const RelayParser = require('RelayParser');
-    const RelayTestSchema = require('RelayTestSchema');
+    if (!schema) {
+      schema = require('RelayTestSchema');
+    }
 
-    const ast = RelayParser.parse(RelayTestSchema, text);
-    let context = new RelayCompilerContext(RelayTestSchema);
+    const ast = RelayParser.parse(schema, text);
+    let context = new RelayCompilerContext(schema);
     context = ast.reduce((ctx, node) => ctx.add(node), context);
     context = (transforms || [])
       .reduce((ctx, {transform}) => transform(ctx), context);

--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -80,6 +80,13 @@ function normalize(
 }
 
 /**
+ * Retrieves either the ID field recorded by the compiler or defaults to `id`.
+ */
+function nodeIDField(field: ConcreteLinkedField, fieldValue: mixed): ?string {
+  return (field.idField && fieldValue[field.idField]) || fieldValue.id;
+}
+
+/**
  * @private
  *
  * Helper for handling payloads.
@@ -241,7 +248,7 @@ class RelayResponseNormalizer {
       storageKey,
     );
     const nextID =
-      fieldValue.id ||
+      nodeIDField(field, fieldValue) ||
       // Reuse previously generated client IDs
       RelayModernRecord.getLinkedRecordID(record, storageKey) ||
       generateRelayClientID(RelayModernRecord.getDataID(record), storageKey);
@@ -290,7 +297,7 @@ class RelayResponseNormalizer {
       );
 
       const nextID =
-        item.id ||
+        nodeIDField(field, item) ||
         (prevIDs && prevIDs[nextIndex]) || // Reuse previously generated client IDs
         generateRelayClientID(
           RelayModernRecord.getDataID(record),

--- a/packages/relay-runtime/store/__tests__/__snapshots__/RelayResponseNormalizer-test.js.snap
+++ b/packages/relay-runtime/store/__tests__/__snapshots__/RelayResponseNormalizer-test.js.snap
@@ -151,3 +151,30 @@ Object {
   },
 }
 `;
+
+exports[`RelayResponseNormalizer normalizes queries with custom Node "DataID" fields 1`] = `
+Object {
+  "Artist:banksy": Object {
+    "__id": "Artist:banksy",
+    "__typename": "Artist",
+    "name": "Banksy",
+  },
+  "Artwork:good-song": Object {
+    "__id": "Artwork:good-song",
+    "__typename": "Artwork",
+    "artists": Object {
+      "__refs": Array [
+        "Artist:banksy",
+      ],
+    },
+    "title": "Good Song",
+  },
+  "client:root": Object {
+    "__id": "client:root",
+    "__typename": "__Root",
+    "node{\\"customID\\":\\"Artwork:good-song\\"}": Object {
+      "__ref": "Artwork:good-song",
+    },
+  },
+}
+`;

--- a/packages/relay-runtime/util/RelayConcreteNode.js
+++ b/packages/relay-runtime/util/RelayConcreteNode.js
@@ -78,6 +78,7 @@ export type ConcreteLinkedField = {
   plural: boolean,
   selections: Array<ConcreteSelection>,
   storageKey: ?string,
+  idField: ?string,
 };
 export type ConcreteLinkedHandle = {
   alias: ?string,


### PR DESCRIPTION
This is Relay v1.3.0 patched to inflect the ID from our schema, which in our case is `__id`.

Now that this is merged into Emission master https://github.com/artsy/emission/pull/616, we’ll start extensive testing and I’ll start cleaning up the commits in this branch, see if things can be improved, and send an upstream PR.

In Emission we’re actually using a slightly modified version of this branch, which:
* Has a very simple [TypeScript transform step](https://github.com/alloy/relay/commit/a1a61f28b5deb15b89aa15a709e7e35b1e1befdb), which is easier to maintain than [TODO](), the hope is that we can replace all of that by just using Babel 7 which has a TS parser.
* A patch that [fixes a case where the stack would overflow](https://github.com/alloy/relay/commit/071f05ba27fa86e2252b519081e8a4a60b76a107) in `QLPrinter`. Need to research if this is a fluke or a legitimate Relay bug.